### PR TITLE
config update for the RestSharp package

### DIFF
--- a/EAN.Api.Tests/EAN.Api.Tests.csproj
+++ b/EAN.Api.Tests/EAN.Api.Tests.csproj
@@ -6,7 +6,7 @@
     <ProjectGuid>{90F4F401-C815-430D-8BE6-365ACBC8D0A1}</ProjectGuid>
     <OutputType>Library</OutputType>
     <NoStandardLibraries>false</NoStandardLibraries>
-    <AssemblyName>ClassLibrary</AssemblyName>
+    <AssemblyName>EAN.Api.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>

--- a/EAN.Api/EAN.Api.csproj
+++ b/EAN.Api/EAN.Api.csproj
@@ -33,7 +33,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="RestSharp, Version=105.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\RestSharp.105.1.0\lib\net4\RestSharp.dll</HintPath>
+      <HintPath>..\packages\RestSharp.105.1.0\lib\net4\RestSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/EAN.Api/EAN.Api.csproj
+++ b/EAN.Api/EAN.Api.csproj
@@ -6,7 +6,7 @@
     <ProjectGuid>{D2BD2907-05C7-453C-A1FD-C89BB79FC4E3}</ProjectGuid>
     <OutputType>Library</OutputType>
     <NoStandardLibraries>false</NoStandardLibraries>
-    <AssemblyName>ClassLibrary</AssemblyName>
+    <AssemblyName>EAN.Api</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>

--- a/EAN.Api/packages.config
+++ b/EAN.Api/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="RestSharp" version="105.1.0" targetFramework="net4" userInstalled="true" />
+  <package id="RestSharp" version="105.1.0" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
I think the path to the RestSharp reference was off, it was saying it could not be found, and it wasn't downloading it automatically. I just removed it and added it back through nuget.
